### PR TITLE
JP-2259

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,8 @@ associations
 documentation
 -------------
 
+- Remove ``sphinx-asdf`` fix issue where menu does not scroll. [#8196]
+
 - Fixed small typo in ``user_documentation`` docs. [#8178]
 
 - Added additional information for the ``scale`` and ``snr`` parameters

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,10 +28,16 @@ extract_1d
 - Fixed a bug in the calling of optional MIRI MRS 1d residual fringe
   correction that could cause defringing to fail in some cases. [#8180]
 
+outlier_detection
+-----------------
+
+- Removed ``grow`` from the ``outlier_detection`` step parameters,
+  because it's no longer used in the algorithms. [#8190]
+
 tweakreg
 --------
 
-- Update sregion after WCS corrections are applied. [#8158]
+- Update ``sregion`` after WCS corrections are applied. [#8158]
 
 
 1.13.3 (01-05-2024)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -130,7 +130,6 @@ extensions = [
     'sphinx_automodapi.automodsumm',
     'sphinx_automodapi.autodoc_enhancements',
     'sphinx_automodapi.smart_resolver',
-    'sphinx_asdf',
 ]
 
 

--- a/jwst/outlier_detection/outlier_detection_step.py
+++ b/jwst/outlier_detection/outlier_detection_step.py
@@ -58,7 +58,6 @@ class OutlierDetectionStep(Step):
         nlow = integer(default=0)
         nhigh = integer(default=0)
         maskpt = float(default=0.7)
-        grow = integer(default=1)
         snr = string(default='5.0 4.0')
         scale = string(default='1.2 0.7')
         backg = float(default=0.0)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,7 +122,6 @@ report_crds_context = "pytest_crds.plugin"
 docs = [
     "matplotlib",
     "sphinx",
-    "sphinx-asdf>=0.1.2",
     "sphinx-astropy",
     "sphinx-automodapi",
     "sphinx-rtd-theme",


### PR DESCRIPTION
<!-- If this PR closes a JIRA ticket, make sure the title starts with the JIRA issue number,
for example JP-1234: <Fix a bug> -->
Resolves [JP-2259](https://jira.stsci.edu/browse/JP-2259)

<!-- If this PR closes a GitHub issue, reference it here by its number -->
Closes #6295

<!-- describe the changes comprising this PR here -->
This PR addresses inadequate source finding in the tweakreg step when using data where the PSF is undersampled, e.g. NIRISS short-wavelength imaging data. This PR allows the user to select from three different photutils star finding algorithms (DAO, IRAF, and segmentation) and exposes the keyword arguments to each

**Checklist for maintainers**
- [ ] added entry in `CHANGES.rst` within the relevant release section
- [ ] updated or added relevant tests
- [ ] updated relevant documentation
- [ ] added relevant milestone
- [ ] added relevant label(s)
- [ ] ran regression tests, post a link to the Jenkins job below.
      [How to run regression tests on a PR](https://github.com/spacetelescope/jwst/wiki/Running-Regression-Tests-Against-PR-Branches)
- [ ] Make sure the JIRA ticket is [resolved properly](https://github.com/spacetelescope/jwst/wiki/How-to-resolve-JIRA-issues)
